### PR TITLE
Enhance JSF configuration with converters and validators

### DIFF
--- a/src/main/java/com/example/demo/jsf/LocationFormBean.java
+++ b/src/main/java/com/example/demo/jsf/LocationFormBean.java
@@ -1,0 +1,34 @@
+package com.example.demo.jsf;
+
+import com.example.demo.entity.Location;
+import com.example.demo.repository.LocationRepository;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class LocationFormBean implements Serializable {
+    private LocationRepository repository;
+    private Location location = new Location();
+
+    public void setRepository(LocationRepository repository) {
+        this.repository = repository;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public void setLocation(Location location) {
+        this.location = location;
+    }
+
+    public List<Location> getLocations() {
+        return repository.findAll();
+    }
+
+    public String save() {
+        repository.save(location);
+        location = new Location();
+        return "index?faces-redirect=true";
+    }
+}

--- a/src/main/java/com/example/demo/jsf/converter/CoordinateConverter.java
+++ b/src/main/java/com/example/demo/jsf/converter/CoordinateConverter.java
@@ -1,0 +1,28 @@
+package com.example.demo.jsf.converter;
+
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.Converter;
+import javax.faces.convert.ConverterException;
+import javax.faces.convert.FacesConverter;
+
+@FacesConverter("coordinateConverter")
+public class CoordinateConverter implements Converter<Double> {
+
+    @Override
+    public Double getAsObject(FacesContext context, UIComponent component, String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return Double.parseDouble(value.replace(',', '.'));
+        } catch (NumberFormatException e) {
+            throw new ConverterException("Invalid coordinate", e);
+        }
+    }
+
+    @Override
+    public String getAsString(FacesContext context, UIComponent component, Double value) {
+        return value != null ? String.format("%.6f", value) : "";
+    }
+}

--- a/src/main/java/com/example/demo/jsf/validator/LatitudeValidator.java
+++ b/src/main/java/com/example/demo/jsf/validator/LatitudeValidator.java
@@ -1,0 +1,25 @@
+package com.example.demo.jsf.validator;
+
+import javax.faces.application.FacesMessage;
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.validator.FacesValidator;
+import javax.faces.validator.Validator;
+import javax.faces.validator.ValidatorException;
+
+@FacesValidator("latitudeValidator")
+public class LatitudeValidator implements Validator<Double> {
+
+    @Override
+    public void validate(FacesContext context, UIComponent component, Double value) throws ValidatorException {
+        if (value == null) {
+            return;
+        }
+        if (value < -90 || value > 90) {
+            FacesMessage msg = new FacesMessage(FacesMessage.SEVERITY_ERROR,
+                    "Invalid latitude",
+                    "Latitude must be between -90 and 90");
+            throw new ValidatorException(msg);
+        }
+    }
+}

--- a/src/main/java/com/example/demo/jsf/validator/LongitudeValidator.java
+++ b/src/main/java/com/example/demo/jsf/validator/LongitudeValidator.java
@@ -1,0 +1,25 @@
+package com.example.demo.jsf.validator;
+
+import javax.faces.application.FacesMessage;
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.validator.FacesValidator;
+import javax.faces.validator.Validator;
+import javax.faces.validator.ValidatorException;
+
+@FacesValidator("longitudeValidator")
+public class LongitudeValidator implements Validator<Double> {
+
+    @Override
+    public void validate(FacesContext context, UIComponent component, Double value) throws ValidatorException {
+        if (value == null) {
+            return;
+        }
+        if (value < -180 || value > 180) {
+            FacesMessage msg = new FacesMessage(FacesMessage.SEVERITY_ERROR,
+                    "Invalid longitude",
+                    "Longitude must be between -180 and 180");
+            throw new ValidatorException(msg);
+        }
+    }
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,3 @@
+location.add.success=Location added successfully
+validator.latitude=Latitude must be between -90 and 90
+validator.longitude=Longitude must be between -180 and 180

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -1,0 +1,3 @@
+location.add.success=Location added successfully
+validator.latitude=Latitude must be between -90 and 90
+validator.longitude=Longitude must be between -180 and 180

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -1,0 +1,3 @@
+location.add.success=Ubicaci\u00f3n agregada exitosamente
+validator.latitude=La latitud debe estar entre -90 y 90
+validator.longitude=La longitud debe estar entre -180 y 180

--- a/src/main/webapp/WEB-INF/faces-config.xml
+++ b/src/main/webapp/WEB-INF/faces-config.xml
@@ -3,4 +3,59 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_3.xsd"
               version="2.3">
+
+    <application>
+        <el-resolver>org.springframework.web.jsf.el.SpringBeanFacesELResolver</el-resolver>
+        <resource-bundle>
+            <base-name>messages</base-name>
+            <var>msg</var>
+        </resource-bundle>
+        <locale-config>
+            <default-locale>en</default-locale>
+            <supported-locale>es</supported-locale>
+        </locale-config>
+        <state-saving-method>client</state-saving-method>
+        <partial-state-saving>true</partial-state-saving>
+    </application>
+
+    <managed-bean>
+        <managed-bean-name>locationForm</managed-bean-name>
+        <managed-bean-class>com.example.demo.jsf.LocationFormBean</managed-bean-class>
+        <managed-bean-scope>view</managed-bean-scope>
+        <managed-property>
+            <property-name>repository</property-name>
+            <value>#{locationRepository}</value>
+        </managed-property>
+    </managed-bean>
+
+    <converter>
+        <converter-id>coordinateConverter</converter-id>
+        <converter-for-class>java.lang.Double</converter-for-class>
+        <converter-class>com.example.demo.jsf.converter.CoordinateConverter</converter-class>
+    </converter>
+
+    <validator>
+        <validator-id>latitudeValidator</validator-id>
+        <validator-class>com.example.demo.jsf.validator.LatitudeValidator</validator-class>
+    </validator>
+    <validator>
+        <validator-id>longitudeValidator</validator-id>
+        <validator-class>com.example.demo.jsf.validator.LongitudeValidator</validator-class>
+    </validator>
+
+    <navigation-rule>
+        <from-view-id>/index.xhtml</from-view-id>
+        <navigation-case>
+            <from-outcome>success</from-outcome>
+            <to-view-id>/index.xhtml</to-view-id>
+            <redirect/>
+        </navigation-case>
+    </navigation-rule>
+    <navigation-rule>
+        <from-view-id>*</from-view-id>
+        <navigation-case>
+            <from-outcome>home</from-outcome>
+            <to-view-id>/index.xhtml</to-view-id>
+        </navigation-case>
+    </navigation-rule>
 </faces-config>


### PR DESCRIPTION
## Summary
- provide a full `faces-config.xml` with navigation, managed bean, converters and validators
- add location form bean for JSF usage
- implement converter and validators for geographic coordinates
- add i18n message bundles for English and Spanish

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859256ee6c08330b0183705af085d6b